### PR TITLE
Feature content library alternative issue on add another url

### DIFF
--- a/handlers/admin/datamanager/content_library_conditional_alternative.cfc
+++ b/handlers/admin/datamanager/content_library_conditional_alternative.cfc
@@ -122,4 +122,16 @@ component extends="preside.system.base.AdminHandler" {
 			args.extraFilters.append( { filter={ content_library_content=contentId } } );
 		}
 	}
+
+	public void function addRecordAction( event, rc, prc ) {
+		var contentId    = rc.content_library_content ?: "";
+		var addRecordUrl = event.buildAdminLink( linkTo="datamanager.addRecord", queryString="object=content_library_conditional_alternative&content_library_content=#contentId#" );
+
+		runEvent(
+			  event          = "admin.DataManager._addRecordAction"
+			, prePostExempt  = true
+			, private        = true
+			, eventArguments = { audit=true, addAnotherUrl=addRecordUrl, errorUrl=addRecordUrl }
+		);
+	}
 }


### PR DESCRIPTION
Currently the return URL for `addAnotherUrl` & `errorUrl` on `content_library_conditional_alternative.cfc` DM is missing `content_library_content` url param. Thus, added addRecordAction on `content_library_conditional_alternative.cfc` DM to manipulate the url for `addAnotherUrl` & `errorUrl`.